### PR TITLE
Updating image to avoid duplication

### DIFF
--- a/collections/cell-segmentation-course.yml
+++ b/collections/cell-segmentation-course.yml
@@ -19,7 +19,7 @@ description: >
 
 # Provide a cover image for the collection. 
 # This must be at least 1400px and be present in the top-level `images` folder in this repo
-cover_image: national-cancer-institute-evhLgfOjU5Y-unsplash.jpg
+cover_image: national-cancer-institute-4zA4w-dr5WM-unsplash-thumb.jpg
 
 # the list of plugins in this collection
 plugins:


### PR DESCRIPTION
Changing the image in the cell segmentation course collection to avoid duplication with the alfa cohort collection